### PR TITLE
Add name generation using external data

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,15 @@
   <audio id="bgm" loop>
     <source src="./Peritune_Swift_Strike_loop.mp3" type="audio/mpeg">
   </audio>
+  <div class="my-4">
+    <select id="nameCategory" class="text-black">
+      <option value="A">A</option>
+      <option value="B">B</option>
+      <option value="D">D</option>
+    </select>
+    <button class="btn" onclick="generateName()">🎲 名前生成</button>
+    <input id="playerName" class="text-black p-2" placeholder="生成された名前" />
+  </div>
 
   <div class="my-4">
     <button class="btn" onclick="startCamera()">📸 カメラを起動</button>
@@ -68,6 +77,7 @@
   </div>
   <div id="log" class="log"></div>
 
+<script src="./name-data/setA.js"></script>
   <script>
     const bgm = document.getElementById('bgm');
     function startBGM() { bgm.currentTime = 0; bgm.play().catch(e => console.log(e)); }
@@ -83,6 +93,23 @@
 
     let players = [];
     let playerCount = 0;
+    function generateName() {
+      var category = document.getElementById("nameCategory").value;
+      var data;
+      if (category === "A") data = window.nameDataA;
+      else if (category === "B") data = window.nameDataB;
+      else if (category === "D") data = window.nameDataD;
+      if (!data || !data.adjectives || !data.nouns || !data.titles) {
+        console.warn("名前データが見つかりません", category);
+        document.getElementById("playerName").value = "";
+        return "";
+      }
+      function rand(arr){ return arr[Math.floor(Math.random() * arr.length)]; }
+      var name = rand(data.adjectives) + rand(data.nouns) + rand(data.titles);
+      document.getElementById("playerName").value = name;
+      return name;
+    }
+
 
     async function startCamera() {
       const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: { exact: 'environment' } } });
@@ -101,14 +128,17 @@
 
     function confirmPhoto() {
       playerCount++;
-      const dataUrl = canvas.toDataURL('image/png');
-      const img = document.createElement('img');
+      var dataUrl = canvas.toDataURL('image/png');
+      var img = document.createElement('img');
       img.src = dataUrl;
-      img.alt = `選手 No.${playerCount}`;
+      var nameInput = document.getElementById('playerName');
+      var generatedName = nameInput.value || `選手 No.${playerCount}`;
+      img.alt = generatedName;
       gallery.appendChild(img);
-      players.push({ no: playerCount, img: dataUrl, name: `選手 No.${playerCount}` });
+      players.push({ no: playerCount, img: dataUrl, name: generatedName });
       canvas.classList.add('hidden');
       confirmBtn.classList.add('hidden');
+      nameInput.value = "";
     }
 
     function getRandomPair() {

--- a/name-data/setA.js
+++ b/name-data/setA.js
@@ -1,0 +1,15 @@
+(function(){
+  var adjectives = [];
+  var nouns = [];
+  var titles = [];
+  for(var i=1;i<=1000;i++){
+    adjectives.push('爆走'+i);
+    nouns.push('ワニ'+i);
+    titles.push('キング'+i);
+  }
+  window.nameDataA = {
+    adjectives: adjectives,
+    nouns: nouns,
+    titles: titles
+  };
+})();


### PR DESCRIPTION
## Summary
- create `name-data/setA.js` with placeholder generator for 1000 entries
- add UI elements for choosing a name set and generating names
- include `setA.js` in the page
- implement `generateName()` and update `confirmPhoto()` to use generated name

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684404059824832d8729df69a1f87deb