### PR TITLE
Enhance registration gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,16 @@
       box-shadow: 0 0 10px #f87171;
       cursor: pointer;
     }
+    .gallery .player-container {
+      margin: 0.5rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .gallery .player-container input {
+      margin-top: 0.25rem;
+      max-width: 120px;
+    }
     .gallery img.selected {
       border-color: #34d399;
       box-shadow: 0 0 10px #34d399;
@@ -73,7 +83,7 @@
       <option value="B">B = Dark Style（闇系）</option>
       <option value="D">D = Random Mixed（ランダム混合）</option>
     </select>
-    <button class="btn" onclick="handleGenerateName()">🎲 名前生成</button>
+    <button class="btn" onclick="handleGenerateName()">🎲 名前を生成</button>
     <input id="playerName" class="text-black p-2" placeholder="生成された名前" />
     <button class="btn" onclick="registerPlayer()">✅ 確定して登録</button>
   </div>
@@ -166,10 +176,22 @@
       if (!currentImage) return;
       playerCount++;
       players.push({ no: playerCount, name, img: currentImage });
+      const playerIndex = players.length - 1;
+      const container = document.createElement('div');
+      container.className = 'player-container';
       const img = document.createElement('img');
       img.src = currentImage;
       img.alt = name;
-      gallery.appendChild(img);
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.value = name;
+      input.className = 'mt-1 px-2 py-1 rounded text-black text-center';
+      input.addEventListener('input', (e) => {
+        players[playerIndex].name = e.target.value;
+      });
+      container.appendChild(img);
+      container.appendChild(input);
+      gallery.appendChild(container);
       playerNameInput.value = '';
       nameSection.classList.add('hidden');
       canvas.classList.add('hidden');


### PR DESCRIPTION
## Summary
- label update in the name generation section
- show player name input below each registered photo
- keep player array in sync with user edits

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684417b9376c832d81265ec050ec711b