### PR TITLE
Implement image generation feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
   <button id="confirmBtn" class="btn hidden" onclick="confirmPhoto()">✅ この画像を使う</button>
 
   <div id="nameSection" class="my-4 hidden">
+    <button id="generateImageBtn" class="btn mb-2" onclick="generateAIImage()">画像を生成</button>
     <button class="btn" onclick="generateName()">🎲 名前を生成</button>
     <input id="playerName" class="text-black p-2" placeholder="生成された名前" />
     <button class="btn" onclick="registerPlayer()">✅ 確定して登録</button>
@@ -103,6 +104,7 @@
     const takeBtn = document.getElementById('takePhoto');
     const confirmBtn = document.getElementById('confirmBtn');
     const nameSection = document.getElementById('nameSection');
+    const generateBtn = document.getElementById('generateImageBtn');
     const playerNameInput = document.getElementById('playerName');
     const ctx = canvas.getContext('2d');
     const gallery = document.getElementById('gallery');
@@ -110,6 +112,7 @@
 
     let players = [];
     let playerCount = 0;
+    let originalImage = null;
     let currentImage = null;
 
     async function startCamera() {
@@ -153,7 +156,8 @@
 
 
     function confirmPhoto() {
-      currentImage = canvas.toDataURL('image/png');
+      originalImage = canvas.toDataURL('image/png');
+      currentImage = originalImage;
       confirmBtn.classList.add('hidden');
       takeBtn.classList.add('hidden');
       if (video.srcObject) {
@@ -161,19 +165,48 @@
       }
       video.classList.add('hidden');
       nameSection.classList.remove('hidden');
+      generateBtn.classList.remove('hidden');
+    }
+
+    async function generateAIImage() {
+      if (!originalImage) return;
+      try {
+        const res = await fetch('/.netlify/functions/generateImage', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ imageData: originalImage })
+        });
+        const data = await res.json();
+        if (data.generatedImage) {
+          currentImage = data.generatedImage;
+          const img = new Image();
+          img.onload = () => {
+            canvas.width = img.width;
+            canvas.height = img.height;
+            ctx.drawImage(img, 0, 0);
+          };
+          img.src = currentImage;
+        }
+      } catch (e) {
+        console.error(e);
+      }
     }
 
     function registerPlayer() {
       const name = playerNameInput.value || generateName();
-      if (!currentImage) return;
+      if (!originalImage || !currentImage) return;
       playerCount++;
-      players.push({ no: playerCount, name, img: currentImage });
+      players.push({ no: playerCount, name, img: originalImage, generatedImg: currentImage });
       const playerIndex = players.length - 1;
       const container = document.createElement('div');
       container.className = 'player-container';
       const img = document.createElement('img');
       img.src = currentImage;
       img.alt = name;
+      const regen = document.createElement('button');
+      regen.textContent = '画像を再生成';
+      regen.className = 'btn mt-1';
+      regen.addEventListener('click', () => regenerateImage(playerIndex, img));
       const input = document.createElement('input');
       input.type = 'text';
       input.value = name;
@@ -182,13 +215,33 @@
         players[playerIndex].name = e.target.value;
       });
       container.appendChild(img);
+      container.appendChild(regen);
       container.appendChild(input);
       gallery.appendChild(container);
       playerNameInput.value = '';
       nameSection.classList.add('hidden');
       canvas.classList.add('hidden');
+      generateBtn.classList.add('hidden');
       log.innerHTML = `✅ ${name} を登録しました！`;
       currentImage = null;
+      originalImage = null;
+    }
+
+    async function regenerateImage(index, imgEl) {
+      try {
+        const res = await fetch('/.netlify/functions/generateImage', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ imageData: players[index].img })
+        });
+        const data = await res.json();
+        if (data.generatedImage) {
+          players[index].generatedImg = data.generatedImage;
+          imgEl.src = data.generatedImage;
+        }
+      } catch (e) {
+        console.error(e);
+      }
     }
 
     function getRandomPair(list) {

--- a/netlify/functions/generateImage.js
+++ b/netlify/functions/generateImage.js
@@ -1,0 +1,19 @@
+exports.handler = async function(event, context) {
+  try {
+    const { imageData } = JSON.parse(event.body);
+
+    // Placeholder logic: In a real implementation, call an image generation API here.
+    // For now, simply echo back the sent image.
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ generatedImage: imageData })
+    };
+  } catch (err) {
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: err.message })
+    };
+  }
+};


### PR DESCRIPTION
## Summary
- add a netlify function `generateImage` as a placeholder for image generation
- expose `画像を生成` button after a photo is confirmed
- support repeated generation and store both original and generated images
- allow regeneration from the gallery via `画像を再生成` button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68441f365248832d905166031def3947