### PR TITLE
Add logging and fix generateImage response

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,15 +214,18 @@
       logStatus('🎯 画像生成リクエスト送信中...');
 
       try {
+        console.log('Client: sending image generation request', currentPrompt);
         const res = await fetch('/.netlify/functions/generateImage', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ prompt: currentPrompt })
         });
+        console.log('Client: response status', res.status);
         const data = await res.json();
-        if (data.imageUrl) {
-          currentImage = data.imageUrl;
-          previewImage.src = data.imageUrl;
+        console.log('Client: response data', data);
+        if (data.generatedImage) {
+          currentImage = data.generatedImage;
+          previewImage.src = data.generatedImage;
           previewImage.classList.remove('hidden');
           confirmBtn.classList.remove('hidden');
           logStatus('✅ 画像生成完了');
@@ -280,15 +283,18 @@
 
       async function regenerateImage(index, imgEl, container) {
         try {
+          console.log('Client: regenerating image for player', index);
           const res = await fetch('/.netlify/functions/generateImage', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ prompt: players[index].prompt })
           });
+          console.log('Client: regen response status', res.status);
           const data = await res.json();
-          if (data.imageUrl) {
-            players[index].img = data.imageUrl;
-            imgEl.src = data.imageUrl;
+          console.log('Client: regen response data', data);
+          if (data.generatedImage) {
+            players[index].img = data.generatedImage;
+            imgEl.src = data.generatedImage;
           }
         } catch (e) {
           console.error(e);

--- a/netlify/functions/generateImage.js
+++ b/netlify/functions/generateImage.js
@@ -4,8 +4,12 @@ exports.handler = async function (event) {
     return { statusCode: 405, body: 'Method Not Allowed' };
   }
 
+  console.log('generateImage called');
+
   try {
     const { prompt } = JSON.parse(event.body || '{}');
+    console.log('Request body parsed:', { prompt });
+
     if (!prompt) {
       return {
         statusCode: 400,
@@ -14,6 +18,7 @@ exports.handler = async function (event) {
       };
     }
 
+    console.log('Calling OpenAI with prompt:', prompt);
     const res = await fetch('https://api.openai.com/v1/images/generations', {
       method: 'POST',
       headers: {
@@ -23,8 +28,14 @@ exports.handler = async function (event) {
       body: JSON.stringify({ prompt, n: 1, size: '512x512' })
     });
 
+    console.log('OpenAI response status:', res.status);
+
     const data = await res.json();
+    console.log('OpenAI response JSON:', data);
+
     const url = data?.data?.[0]?.url;
+    console.log('Generated image URL:', url);
+
     if (!url) {
       return {
         statusCode: 500,
@@ -36,9 +47,10 @@ exports.handler = async function (event) {
     return {
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ imageUrl: url })
+      body: JSON.stringify({ generatedImage: url })
     };
   } catch (err) {
+    console.log('Error in generateImage:', err);
     return {
       statusCode: 500,
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- log details on the server in `generateImage` function
- return `generatedImage` in the API response
- adjust frontend to use the new property
- add client-side console logs for fetch flow

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68443e08c144832dbc6c581f874215ed