### PR TITLE
Implement tournament bracket

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,16 @@
       border-color: #34d399;
       box-shadow: 0 0 10px #34d399;
     }
+    .gallery img.winner {
+      border-color: #facc15;
+      box-shadow: 0 0 15px #facc15;
+    }
+    #champion img {
+      max-width: 200px;
+      border: 4px solid #facc15;
+      border-radius: 10px;
+      box-shadow: 0 0 15px #facc15;
+    }
     .badge {
       position: absolute;
       top: 2px;
@@ -96,6 +106,7 @@
     <button class="btn" onclick="startBattle()">🥊 トーナメント開始</button>
   </div>
   <div id="log" class="log"></div>
+  <div id="champion" class="mt-8"></div>
 
 
 <script src="./name-data/setA.js"></script>
@@ -303,6 +314,7 @@
       container.appendChild(regen);
       container.appendChild(input);
       gallery.appendChild(container);
+      players[playerIndex].container = container;
       playerNameInput.value = '';
       if(charInfoEl) {
         charInfoEl.classList.add('hidden');
@@ -366,18 +378,73 @@
       }
     }
 
+    function sleep(ms) {
+      return new Promise(res => setTimeout(res, ms));
+    }
+
+    function highlightWinner(p) {
+      if (!p.container) return;
+      const img = p.container.querySelector('img');
+      if (img) img.classList.add('winner');
+    }
+
+    function clearHighlights() {
+      players.forEach(pl => {
+        if (pl.container) {
+          const img = pl.container.querySelector('img');
+          if (img) img.classList.remove('winner');
+        }
+      });
+    }
+
+    function showChampion(p) {
+      const champ = document.getElementById('champion');
+      champ.innerHTML = `<h2 class="text-2xl text-yellow-300">🏆 優勝: ${p.name}！</h2>` +
+        `<img src="${p.img}" alt="${p.name}" class="mx-auto my-2" />`;
+    }
+
+    async function runTournament(list) {
+      let round = 1;
+      let current = [...list].sort(() => Math.random() - 0.5);
+      clearHighlights();
+      log.innerHTML = '';
+      while (current.length > 1) {
+        log.innerHTML += `\n--- Round ${round} ---\n`;
+        const next = [];
+        for (let i = 0; i < current.length; i += 2) {
+          const a = current[i];
+          const b = current[i + 1];
+          if (!b) {
+            log.innerHTML += `✅ ${a.name} は不戦勝で次のラウンドへ\n`;
+            next.push(a);
+            continue;
+          }
+          log.innerHTML += `\n<strong>対戦カード:</strong> ${a.name} vs ${b.name}<br>📡 実況生成中...\n`;
+          const text = await generateBattleText(a.name, b.name);
+          const winner = Math.random() < 0.5 ? a : b;
+          log.innerHTML += `${text}\n🏅 勝者: ${winner.name}\n`;
+          highlightWinner(winner);
+          next.push(winner);
+          await sleep(1000);
+        }
+        current = next;
+        round++;
+        await sleep(1000);
+      }
+      const champion = current[0];
+      log.innerHTML += `\n🏆 優勝: ${champion.name}！\n`;
+      highlightWinner(champion);
+      showChampion(champion);
+    }
+
     async function startBattle() {
       const readyPlayers = players.filter(p => p.name);
       if (readyPlayers.length < 2) {
         log.innerHTML = "⚠️ 名前登録済みの選手を最低2人用意してください！";
         return;
       }
-
-      const [a, b] = getRandomPair(readyPlayers);
-      log.innerHTML = `<strong>対戦カード:</strong> ${a.name} vs ${b.name}<br>📡 実況生成中...`;
-
-      const text = await generateBattleText(a.name, b.name);
-      log.innerHTML += `<br><strong>🧠 実況結果:</strong><br>${text}`;
+      document.getElementById('champion').innerHTML = '';
+      await runTournament(readyPlayers);
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add highlight and champion display styles
- store player container in player object
- implement full tournament logic with rounds and final champion

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844d7ab033c832dac96d88ff5920ddc