### PR TITLE
Fix BGM playback logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
 
   <button class="btn" onclick="startBGM()">🎵 BGM再生</button>
   <button class="btn" onclick="stopBGM()">🔇 BGM停止</button>
-  <audio id="bgm" muted autoplay loop>
+  <audio id="bgm" muted loop>
     <source src="./Peritune_Swift_Strike_loop.mp3" type="audio/mpeg">
   </audio>
   <audio id="fanfare">
@@ -143,13 +143,13 @@
       "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=";
     const bgm = document.getElementById('bgm');
     function startBGM() {
-      bgm.muted = false;
-      bgm.currentTime = 0;
-      if (bgm.load) bgm.load();
-      bgm.play().catch(e => {
-        console.log('Playback error:', e);
-        console.warn('BGM playback requires a user gesture.');
-      });
+      if (bgm.paused) {
+        bgm.muted = false;
+        bgm.currentTime = 0;
+        bgm.play().catch(e => console.warn("BGM play failed, possibly due to browser restrictions:", e));
+      } else {
+        console.log("BGM is already playing.");
+      }
     }
     function stopBGM() { bgm.pause(); }
 


### PR DESCRIPTION
## Summary
- stop autoplaying BGM on page load
- unmute and play audio only after button click
- handle errors when playback fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844e8df3be8832d84b988ea0a6968b6